### PR TITLE
Allow custom handling of non-Boom errors + TypeScript typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ const formatErrorOptions = {
     // If the error is internal error this error will be a wrapped internal error which not contains the sensitive details
     // This is the error which will be sent to the client
     onFinalError: (finalError) => {logger.info(finalError.message)},
-  }
+  },
+  nonBoomTransformer: (nonBoomError) => {error instanceof GraphQLError ? SevenBoom.badRequest(error.message) : SevenBoom.badImplementation(error)}
+  // Optional function to transform non-Boom errors, such as those from Apollo & other 3rd-party libraries, into Boom errors
 };
 const formatError = formatErrorGenerator(formatErrorOptions);
 const app = express();

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,121 @@
+// Type definitions for `graphql-apollo-errors`
+// Project: https://github.com/GiladShoham/graphql-apollo-errors
+// Definitions by: Keith Gillette <https://github.com/KeithGillette>
+
+export function formatErrorGenerator(options: FormatErrorOptions): FormatErrorFunction;
+
+export interface ArgumentDefinition {
+  name: string;
+  order: number;
+  default: string | Function | null | undefined;
+}
+
+export interface ErrorResult {
+  isBoom: boolean;
+  isServer: boolean;
+  message: string;
+  data: any;
+  output: {
+    statusCode: string;
+    payload: ErrorPayload
+  };
+}
+
+export interface ErrorPayload {
+  statusCode: string;
+  error: string;
+  message: string;
+  errorName?: string;
+  timeThrown?: string;
+  guid?: string;
+
+  [key: string]: any;
+
+  data: any;
+}
+
+export interface FormatErrorOptions {
+  logger?: Function;
+  publicDataPath?: string;
+  showLocations?: boolean;
+  showPath?: boolean;
+  hideSensitiveData?: boolean;
+  hooks?: {
+    onOriginalError?: (originalError: any) => void;
+    onProcessedError?: (processedError: any) => void;
+    onFinalError?: (finalError: any) => void;
+  };
+  nonBoomTransformer?: (error: any) => ErrorResult;
+}
+
+export interface FormatErrorFunction {
+  (graphQLError: any): any;
+}
+
+export declare module SevenBoom {
+
+  export function init(argsDefs: ArgumentDefinition[]): void;
+
+  export function wrap(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function create(statusCode: number, errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function badRequest(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function unauthorized(errorMessage: string, scheme?: string | string[], attributes?: { [key: string]: any }): ErrorResult;
+
+  export function paymentRequired(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function forbidden(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function notFound(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function methodNotAllowed(errorMessage?: string, errorData?: any, allow?: string | string[]): ErrorResult;
+
+  export function notAcceptable(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function proxyAuthRequired(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function clientTimeout(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function conflict(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function resourceGone(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function lengthRequired(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function preconditionFailed(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function entityTooLarge(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function uriTooLong(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function unsupportedMediaType(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function rangeNotSatisfiable(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function expectationFailed(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function teapot(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function badData(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function locked(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function preconditionRequired(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function tooManyRequests(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function illegal(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function badImplementation(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function notImplemented(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function badGateway(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function serverUnavailable(errorMessage?: string, errorData?: any): ErrorResult;
+
+  export function gatewayTimeout(errorMessage?: string, errorData?: any): ErrorResult;
+
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,18 @@
-var log = require('minilog')('grpahql-apollo-error');
+const log = require('minilog')('graphql-apollo-error');
 require('minilog').enable();
 import _ from 'lodash';
 import SevenBoom from 'seven-boom';
 
 const defaultArgsDef = [
   {
-    name : 'errorCode',
+    name: 'errorCode',
     order: 1
   }, {
-    name : 'timeThrown',
+    name: 'timeThrown',
     order: 2,
     default: null
   }, {
-    name : 'guid',
+    name: 'guid',
     order: 3,
     default: null
   }
@@ -24,9 +24,9 @@ const defaultFormatErrorOptions = {
   publicDataPath: '',
   hideSensitiveData: true,
   hooks: {}
-}
+};
 
-export { SevenBoom };
+export {SevenBoom};
 
 export const initSevenBoom = (argsDef) => {
   SevenBoom.init(argsDef);
@@ -34,39 +34,43 @@ export const initSevenBoom = (argsDef) => {
 
 export const formatErrorGenerator = (formatErrorOptions) => {
   const actualOptions = _.defaults(formatErrorOptions, defaultFormatErrorOptions);
-  let {logger, publicDataPath, hooks, showLocations, showPath, hideSensitiveData} = actualOptions;
+  let {logger, publicDataPath, hooks, showLocations, showPath, hideSensitiveData, nonBoomTransformer} = actualOptions;
   const {onOriginalError, onProcessedError, onFinalError} = hooks;
   publicDataPath = publicDataPath ? `data.${publicDataPath}` : 'data';
 
-  return function formatError (graphqlError) {
+  return function formatError(graphqlError) {
 
     let err = graphqlError.originalError || graphqlError;
 
-    if (onOriginalError && _.isFunction(onOriginalError)){
+    if (onOriginalError && _.isFunction(onOriginalError)) {
       onOriginalError(err)
     }
 
     if (err === undefined || !err.isBoom) {
-      logger[logger.info ? 'info' : 'log']('Transform error to boom error');
-      err = SevenBoom.wrap(err, 500);
+      if (nonBoomTransformer && _.isFunction(nonBoomTransformer)) {
+        err = nonBoomTransformer(err)
+      } else {
+        logger[logger.info ? 'info' : 'log'](`Transform error to boom error: ${err}`);
+        err = SevenBoom.wrap(err, 500);
+      }
     }
 
-    if (showLocations){
+    if (showLocations) {
       err.output.payload.locations = graphqlError.locations;
     }
 
-    if (showPath){
+    if (showPath) {
       err.output.payload.path = graphqlError.path;
     }
 
-    if (onProcessedError && _.isFunction(onProcessedError)){
+    if (onProcessedError && _.isFunction(onProcessedError)) {
       onProcessedError(err)
     }
 
     err.output.payload.data = _.get(err, publicDataPath, {});
     let finalError = err.output.payload;
 
-    // Special implemantation for internal server errors
+    // Special implementation for internal server errors
     if (err.isServer && hideSensitiveData) {
       // logger.error(err);
       delete finalError.data;
@@ -74,10 +78,10 @@ export const formatErrorGenerator = (formatErrorOptions) => {
       // logger.debug(err);
     }
 
-    if (onFinalError && _.isFunction(onFinalError)){
+    if (onFinalError && _.isFunction(onFinalError)) {
       onFinalError(finalError)
     }
 
     return finalError;
   };
-}
+};


### PR DESCRIPTION
Per our discussion on #4, I finally got around to adding a `nonBoomTransformer` to allow custom handling of non-Boom errors. I also took a stab at adding typings, since I use TypeScript.