### PR TITLE
Update index.d.ts with errorCode argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,66 +56,66 @@ export declare module SevenBoom {
 
   export function init(argsDefs: ArgumentDefinition[]): void;
 
-  export function wrap(errorMessage?: string, errorData?: any): ErrorResult;
+  export function wrap(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function create(statusCode: number, errorMessage?: string, errorData?: any): ErrorResult;
+  export function create(statusCode: number, errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function badRequest(errorMessage?: string, errorData?: any): ErrorResult;
+  export function badRequest(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function unauthorized(errorMessage: string, scheme?: string | string[], attributes?: { [key: string]: any }): ErrorResult;
+  export function unauthorized(errorMessage: string, scheme?: string | string[], attributes?: { [key: string]: any }, errorCode?: any): ErrorResult;
 
-  export function paymentRequired(errorMessage?: string, errorData?: any): ErrorResult;
+  export function paymentRequired(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function forbidden(errorMessage?: string, errorData?: any): ErrorResult;
+  export function forbidden(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function notFound(errorMessage?: string, errorData?: any): ErrorResult;
+  export function notFound(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function methodNotAllowed(errorMessage?: string, errorData?: any, allow?: string | string[]): ErrorResult;
+  export function methodNotAllowed(errorMessage?: string, errorData?: any, allow?: string | string[], errorCode?: any): ErrorResult;
 
-  export function notAcceptable(errorMessage?: string, errorData?: any): ErrorResult;
+  export function notAcceptable(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function proxyAuthRequired(errorMessage?: string, errorData?: any): ErrorResult;
+  export function proxyAuthRequired(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function clientTimeout(errorMessage?: string, errorData?: any): ErrorResult;
+  export function clientTimeout(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function conflict(errorMessage?: string, errorData?: any): ErrorResult;
+  export function conflict(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function resourceGone(errorMessage?: string, errorData?: any): ErrorResult;
+  export function resourceGone(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function lengthRequired(errorMessage?: string, errorData?: any): ErrorResult;
+  export function lengthRequired(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function preconditionFailed(errorMessage?: string, errorData?: any): ErrorResult;
+  export function preconditionFailed(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function entityTooLarge(errorMessage?: string, errorData?: any): ErrorResult;
+  export function entityTooLarge(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function uriTooLong(errorMessage?: string, errorData?: any): ErrorResult;
+  export function uriTooLong(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function unsupportedMediaType(errorMessage?: string, errorData?: any): ErrorResult;
+  export function unsupportedMediaType(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function rangeNotSatisfiable(errorMessage?: string, errorData?: any): ErrorResult;
+  export function rangeNotSatisfiable(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function expectationFailed(errorMessage?: string, errorData?: any): ErrorResult;
+  export function expectationFailed(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function teapot(errorMessage?: string, errorData?: any): ErrorResult;
+  export function teapot(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function badData(errorMessage?: string, errorData?: any): ErrorResult;
+  export function badData(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function locked(errorMessage?: string, errorData?: any): ErrorResult;
+  export function locked(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function preconditionRequired(errorMessage?: string, errorData?: any): ErrorResult;
+  export function preconditionRequired(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function tooManyRequests(errorMessage?: string, errorData?: any): ErrorResult;
+  export function tooManyRequests(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function illegal(errorMessage?: string, errorData?: any): ErrorResult;
+  export function illegal(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function badImplementation(errorMessage?: string, errorData?: any): ErrorResult;
+  export function badImplementation(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function notImplemented(errorMessage?: string, errorData?: any): ErrorResult;
+  export function notImplemented(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function badGateway(errorMessage?: string, errorData?: any): ErrorResult;
+  export function badGateway(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function serverUnavailable(errorMessage?: string, errorData?: any): ErrorResult;
+  export function serverUnavailable(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
-  export function gatewayTimeout(errorMessage?: string, errorData?: any): ErrorResult;
+  export function gatewayTimeout(errorMessage?: string, errorData?: any, errorCode?: any): ErrorResult;
 
 }


### PR DESCRIPTION
The errorCode option creates an error in TypeScript because it is not part of the index.d.ts file. However ignoring the build errors show that the errorCode is applied to the error result as excepted. Adding errorCode as argument to the methods in index.d.ts, will remove the build error in TypeScript when using the errorCode property.