### PR TITLE
Correct `statusCode` TypeScript type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Enjoy your shiny error on the client
   "data": {},
   "errors": [
     {
-      statusCode: '404',
+      statusCode: 404,
       error: 'Not Found',
       message: 'User with id: 123 not found.',
       code: 'USER_NOT_FOUND',

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,13 +16,13 @@ export interface ErrorResult {
   message: string;
   data: any;
   output: {
-    statusCode: string;
+    statusCode: number;
     payload: ErrorPayload
   };
 }
 
 export interface ErrorPayload {
-  statusCode: string;
+  statusCode: number;
   error: string;
   message: string;
   errorName?: string;


### PR DESCRIPTION
I noticed that the previous TypeScript typings I provided typed `statusCode` properties as strings. However, inspecting the code and actual return data reveals that `statusCode` is numeric, so I have corrected the type definitions and the example error in the README.